### PR TITLE
add xpath sample from CWE-643

### DIFF
--- a/my-go-project/go.mod
+++ b/my-go-project/go.mod
@@ -6,4 +6,9 @@ toolchain go1.21.4
 
 require github.com/lestrrat-go/libxml2 v0.0.0-20231124114421-99c71026c2f5
 
-require github.com/pkg/errors v0.9.1 // indirect
+require golang.org/x/text v0.14.0 // indirect
+
+require (
+	github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6
+	github.com/pkg/errors v0.9.1 // indirect
+)

--- a/my-go-project/go.sum
+++ b/my-go-project/go.sum
@@ -1,3 +1,5 @@
+github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6 h1:w0E0fgc1YafGEh5cROhlROMWXiNoZqApk2PDN0M1+Ns=
+github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/lestrrat-go/libxml2 v0.0.0-20231124114421-99c71026c2f5 h1:lR4DHv41vdkhNPNDlr56n8BuLINQeWNeQAaAzBEOcuw=
@@ -8,5 +10,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/my-go-project/web/vulns/xpath.go
+++ b/my-go-project/web/vulns/xpath.go
@@ -1,0 +1,28 @@
+package vulns
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ChrisTrenkamp/goxpath"
+	"github.com/ChrisTrenkamp/goxpath/tree"
+)
+
+func processRequest(r *http.Request, doc tree.Node) {
+	r.ParseForm()
+	username := r.Form.Get("username")
+
+	// BAD: User input used directly in an XPath expression
+	xPath := goxpath.MustParse("//users/user[login/text()='" + username + "']/home_dir/text()")
+	unsafeRes, _ := xPath.ExecBool(doc)
+	fmt.Println(unsafeRes)
+
+	// GOOD: Value of parameters is defined here instead of directly in the query
+	opt := func(o *goxpath.Opts) {
+		o.Vars["username"] = tree.String(username)
+	}
+	// GOOD: Uses parameters to avoid including user input directly in XPath expression
+	xPath = goxpath.MustParse("//users/user[login/text()=$username]/home_dir/text()")
+	safeRes, _ := xPath.ExecBool(doc, opt)
+	fmt.Println(safeRes)
+}


### PR DESCRIPTION
This pull request primarily focuses on updating the dependencies in the `my-go-project/go.mod` file and introducing a new file `my-go-project/web/vulns/xpath.go` that contains a function to process HTTP requests. The function in the new file demonstrates both a vulnerable and a safe way of using user input in XPath expressions.

Updates to dependencies:

* <a href="diffhunk://#diff-64490166ee5914345811b54b3100a17e36eff5e2dc97e4fe8b4e86dbef4ab8ddL9-R14">`my-go-project/go.mod`</a>: Updated the required dependencies by adding `golang.org/x/text v0.14.0` and `github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6`. Also, the `github.com/pkg/errors v0.9.1` dependency has been moved to a new require block.

New file and function:

* <a href="diffhunk://#diff-ec908b1060fcde9fd252bd9f7a924dcde63c50f9e7ff15423f1967641576aa1bR1-R28">`my-go-project/web/vulns/xpath.go`</a>: Introduced a new file that contains the `processRequest` function. This function processes HTTP requests and demonstrates both a vulnerable and a safe way of using user input in XPath expressions.